### PR TITLE
docs: add emulator plugins explanation

### DIFF
--- a/packages/otso.run/src/content/docs/explanations/emulator-plugins.mdx
+++ b/packages/otso.run/src/content/docs/explanations/emulator-plugins.mdx
@@ -1,0 +1,27 @@
+---
+title: Emulator Plugins
+description: Browse local backups through platform-like interfaces.
+---
+
+Emulator plugins let Otso display exported data with a UI that mirrors the service it came from. Each plugin interprets a platform's layout and metadata so that browsing a local archive feels like using the original site.
+
+## How it works
+1. **Local backup** – content and metadata are stored offline.
+2. **Source-specific plugin** – knows the platform's structure and reproduces its look and behavior.
+3. **Uniform shell** – multiple plugins run in the same host so you can switch between emulated interfaces.
+4. **Interactive browsing** – search, filter, and follow links entirely on local data.
+
+## Advantages
+- Familiar interface for archived content.
+- Backups remain accessible even if the original service disappears.
+- All browsing happens locally for privacy and control.
+- Developers can add plugins for new platforms.
+
+## Inspirations
+- **parallel-flickr** – a reconstruction of Flickr’s photo pages that demonstrates how a backup can feel like the live site.
+- **N64 emulators** – recreate console hardware in software so classic games remain playable on modern machines.
+- **Rhizome Web Recorder** – captures entire browsing sessions for later playback, preserving not just files but the experience.
+
+## Why Emulate?
+Plain archives keep data, but they lose context. Emulating an interface revives the look, behavior, and cultural feel of a platform so that a backup becomes something you can inhabit, not just inspect.
+


### PR DESCRIPTION
## Summary
- add explanation page for emulator plugins that emulate platform UIs over local backups
- cite inspirations like parallel-flickr, N64 emulators, and Rhizome Web Recorder, noting how emulation preserves experience beyond raw backups

## Testing
- `pnpm --filter otso.run build`


------
https://chatgpt.com/codex/tasks/task_e_68c5daad7de08325ab608e23d41767ca