### PR TITLE
docs: add contributing guide and docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,16 @@
 # otso
-Local-first IndieWeb toolkit for archiving, syncing, harmonizing, and publishing your trails and streams.
+
+Otso is a local-first IndieWeb toolkit for archiving, syncing, harmonizing, and publishing your trails and streams.
+
+## Documentation
+
+Full documentation is available at [otso.run](https://otso.run).
+
+## Contributing
+
+We welcome contributions of all kinds and from contributors of every background—from code and docs to design, translations, and community building. Read our [Contributing guide](https://otso.run/overview/contributing/) to get started.
+
+## Open Source Philosophy
+
+Otso is built in the open to empower individuals and communities. We believe software should be transparent, forkable, and shaped by those who use it. By sharing our work and collaborating publicly, we strive to create tools that respect privacy, encourage portability, and grow through collective stewardship.
+

--- a/packages/otso.run/src/content/docs/overview/contributing.mdx
+++ b/packages/otso.run/src/content/docs/overview/contributing.mdx
@@ -1,0 +1,13 @@
+---
+title: Contributing
+description: Ways to participate across roles and skills.
+sidebar:
+  order: 6
+---
+
+We welcome contributions of all kinds and from contributors of every background. Whether you're writing code, improving documentation, shaping user experience, reporting issues, offering translations, or fostering community discussions, your help moves the project forward. If you're new to open source, you're welcome here—start with our issue tracker, ask questions, and share your ideas.
+
+## Open Source Philosophy
+
+Otso is built in the open to empower individuals and communities. We believe software should be transparent, forkable, and shaped by those who use it. By sharing our work and collaborating publicly, we strive to create tools that respect privacy, encourage portability, and grow through collective stewardship.
+


### PR DESCRIPTION
## Summary
- link to project docs site and contributing guide from README
- add docs page describing inclusive ways to contribute and the project's open source philosophy

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68c600ad8674832580752fe8495fdf63