### PR TITLE
docs: organize sidebar page order

### DIFF
--- a/packages/otso.run/src/content/docs/appendix/data-schema-mappings.mdx
+++ b/packages/otso.run/src/content/docs/appendix/data-schema-mappings.mdx
@@ -1,6 +1,8 @@
 ---
 title: Data Schema & Mappings
 description: Schema sketches and mappings (e.g., GitHub → mf2).
+sidebar:
+  order: 2
 ---
 
 Otso keeps the storage model deliberately small. All items are stored as **events** with normalized content and optional media references.

--- a/packages/otso.run/src/content/docs/appendix/deployment-recipes.mdx
+++ b/packages/otso.run/src/content/docs/appendix/deployment-recipes.mdx
@@ -1,6 +1,8 @@
 ---
 title: Deployment Recipes
 description: Vercel, self‑hosted, and scheduling.
+sidebar:
+  order: 4
 ---
 
 Otso runs as a small Node app and does not require special infrastructure. These deployment recipes cover common setups.

--- a/packages/otso.run/src/content/docs/appendix/glossary-faq.mdx
+++ b/packages/otso.run/src/content/docs/appendix/glossary-faq.mdx
@@ -1,6 +1,8 @@
 ---
 title: Glossary & FAQ
 description: Common terms and answers to frequent questions.
+sidebar:
+  order: 1
 ---
 
 ## Glossary

--- a/packages/otso.run/src/content/docs/appendix/plugin-architecture.mdx
+++ b/packages/otso.run/src/content/docs/appendix/plugin-architecture.mdx
@@ -1,6 +1,8 @@
 ---
 title: Plugin Architecture
 description: Plugin manifest, lifecycle, and examples.
+sidebar:
+  order: 3
 ---
 
 Otso plugins extend imports, publishers, and enrichers. A plugin is a Node module exporting a manifest and hooks.

--- a/packages/otso.run/src/content/docs/appendix/security-privacy.mdx
+++ b/packages/otso.run/src/content/docs/appendix/security-privacy.mdx
@@ -1,6 +1,8 @@
 ---
 title: Security & Privacy
 description: Managing secrets, storage boundaries, and privacy rules.
+sidebar:
+  order: 5
 ---
 
 Otso is designed to keep sensitive data local and under your control.

--- a/packages/otso.run/src/content/docs/explanations/ecosystem-alternatives-inspirations.mdx
+++ b/packages/otso.run/src/content/docs/explanations/ecosystem-alternatives-inspirations.mdx
@@ -1,6 +1,8 @@
 ---
 title: Ecosystem — Alternatives & Inspirations
 description: How Otso compares to adjacent projects, with gratitude and links for deeper dives.
+sidebar:
+  order: 6
 ---
 
 Otso lives happily in an ecosystem of IndieWeb and local‑first tools. This page summarizes how Otso differs, when you might choose something else, and how they can play together. We link out with admiration—these projects are great.

--- a/packages/otso.run/src/content/docs/explanations/emulator-plugins.mdx
+++ b/packages/otso.run/src/content/docs/explanations/emulator-plugins.mdx
@@ -1,6 +1,8 @@
 ---
 title: Emulator Plugins
 description: Browse local backups through platform-like interfaces.
+sidebar:
+  order: 5
 ---
 
 Emulator plugins let Otso display exported data with a UI that mirrors the service it came from. Each plugin interprets a platform's layout and metadata so that browsing a local archive feels like using the original site.

--- a/packages/otso.run/src/content/docs/explanations/event-driven-design.mdx
+++ b/packages/otso.run/src/content/docs/explanations/event-driven-design.mdx
@@ -1,6 +1,8 @@
 ---
 title: Event‑Driven Design
 description: Benefits, drawbacks, and a practical mental model.
+sidebar:
+  order: 4
 ---
 
 Otso treats every change as an immutable event. This makes history auditable and projections easy to rebuild.

--- a/packages/otso.run/src/content/docs/explanations/indieweb-alignment.mdx
+++ b/packages/otso.run/src/content/docs/explanations/indieweb-alignment.mdx
@@ -1,6 +1,8 @@
 ---
 title: IndieWeb Alignment
 description: How Otso supports IndieWeb principles.
+sidebar:
+  order: 2
 ---
 
 Otso builds on IndieWeb protocols and encourages publishing on your own domain first.

--- a/packages/otso.run/src/content/docs/explanations/local-first-choices.mdx
+++ b/packages/otso.run/src/content/docs/explanations/local-first-choices.mdx
@@ -1,6 +1,8 @@
 ---
 title: Local‑First Choices
 description: Why Otso prefers local databases and offline‑first workflows.
+sidebar:
+  order: 1
 ---
 
 Running locally keeps your data fast and private.

--- a/packages/otso.run/src/content/docs/explanations/platform-constraints-twitter.mdx
+++ b/packages/otso.run/src/content/docs/explanations/platform-constraints-twitter.mdx
@@ -1,6 +1,8 @@
 ---
 title: Platform Constraints — Twitter/X
 description: Dealing with API limits and archive quirks.
+sidebar:
+  order: 7
 ---
 
 Twitter’s shifting APIs and export formats require extra care.

--- a/packages/otso.run/src/content/docs/explanations/posse-vs-pesos.mdx
+++ b/packages/otso.run/src/content/docs/explanations/posse-vs-pesos.mdx
@@ -1,6 +1,8 @@
 ---
 title: POSSE vs PESOS
 description: When to syndicate out vs. import back.
+sidebar:
+  order: 3
 ---
 
 Two common IndieWeb workflows:

--- a/packages/otso.run/src/content/docs/how-to/configure-visibility.mdx
+++ b/packages/otso.run/src/content/docs/how-to/configure-visibility.mdx
@@ -1,6 +1,8 @@
 ---
 title: Configure Visibility
 description: Use public, unlisted, private, and secret visibility.
+sidebar:
+  order: 9
 ---
 
 Events carry a `visibility` property to control where content appears.

--- a/packages/otso.run/src/content/docs/how-to/import-bluesky.mdx
+++ b/packages/otso.run/src/content/docs/how-to/import-bluesky.mdx
@@ -1,6 +1,8 @@
 ---
 title: Import from Bluesky
 description: Import from Bluesky with cursor-based pagination.
+sidebar:
+  order: 5
 ---
 
 Otso’s Bluesky adapter pulls posts via the public API.

--- a/packages/otso.run/src/content/docs/how-to/import-github.mdx
+++ b/packages/otso.run/src/content/docs/how-to/import-github.mdx
@@ -1,6 +1,8 @@
 ---
 title: Import from GitHub
 description: Bring GitHub activity into Otso.
+sidebar:
+  order: 6
 ---
 
 Track your commits, issues, and stars.

--- a/packages/otso.run/src/content/docs/how-to/import-mastodon.mdx
+++ b/packages/otso.run/src/content/docs/how-to/import-mastodon.mdx
@@ -1,6 +1,8 @@
 ---
 title: Import from Mastodon
 description: Import your Mastodon timeline or account archive.
+sidebar:
+  order: 4
 ---
 
 ## Using the API

--- a/packages/otso.run/src/content/docs/how-to/import-twitter-archives.mdx
+++ b/packages/otso.run/src/content/docs/how-to/import-twitter-archives.mdx
@@ -1,6 +1,8 @@
 ---
 title: Import Twitter/X Archive
 description: Import your Twitter/X export and map to Otso kinds.
+sidebar:
+  order: 7
 ---
 
 ## Prepare the archive

--- a/packages/otso.run/src/content/docs/how-to/manage-media-alttext-tags.mdx
+++ b/packages/otso.run/src/content/docs/how-to/manage-media-alttext-tags.mdx
@@ -1,6 +1,8 @@
 ---
 title: Manage Media, Alt‑text, and Tags
 description: Handle assets, generate alt‑text, and organize with tags.
+sidebar:
+  order: 8
 ---
 
 ## Media storage

--- a/packages/otso.run/src/content/docs/how-to/publish-bluesky.mdx
+++ b/packages/otso.run/src/content/docs/how-to/publish-bluesky.mdx
@@ -1,6 +1,8 @@
 ---
 title: Publish to Bluesky
 description: POSSE to Bluesky with app passwords.
+sidebar:
+  order: 3
 ---
 
 ## Setup

--- a/packages/otso.run/src/content/docs/how-to/publish-mastodon.mdx
+++ b/packages/otso.run/src/content/docs/how-to/publish-mastodon.mdx
@@ -1,6 +1,8 @@
 ---
 title: Publish to Mastodon
 description: POSSE to Mastodon while keeping your site as the source.
+sidebar:
+  order: 2
 ---
 
 ## Connect account

--- a/packages/otso.run/src/content/docs/how-to/publish-micropub.mdx
+++ b/packages/otso.run/src/content/docs/how-to/publish-micropub.mdx
@@ -1,6 +1,8 @@
 ---
 title: Publish via Micropub
 description: Configure Micropub and publish to your site.
+sidebar:
+  order: 1
 ---
 
 ## IndieAuth

--- a/packages/otso.run/src/content/docs/how-to/schedule-sync-vercel-upstash.mdx
+++ b/packages/otso.run/src/content/docs/how-to/schedule-sync-vercel-upstash.mdx
@@ -1,6 +1,8 @@
 ---
 title: Schedule Sync (Vercel Cron / Upstash)
 description: Run periodic sync jobs in production.
+sidebar:
+  order: 10
 ---
 
 ## Vercel cron

--- a/packages/otso.run/src/content/docs/reference/apis-endpoints.mdx
+++ b/packages/otso.run/src/content/docs/reference/apis-endpoints.mdx
@@ -1,6 +1,8 @@
 ---
 title: APIs & Endpoints
 description: Micropub, Webmention, and internal HTTP endpoints.
+sidebar:
+  order: 5
 ---
 
 ## Micropub

--- a/packages/otso.run/src/content/docs/reference/cli-commands.mdx
+++ b/packages/otso.run/src/content/docs/reference/cli-commands.mdx
@@ -1,6 +1,8 @@
 ---
 title: CLI Commands
 description: Command reference with flags and examples.
+sidebar:
+  order: 1
 ---
 
 The `otso` CLI orchestrates imports, publishing, and maintenance.

--- a/packages/otso.run/src/content/docs/reference/event-model.mdx
+++ b/packages/otso.run/src/content/docs/reference/event-model.mdx
@@ -1,6 +1,8 @@
 ---
 title: Event Model
 description: Event categories, fields, and before/after policy.
+sidebar:
+  order: 2
 ---
 
 Events capture every action Otso takes.

--- a/packages/otso.run/src/content/docs/reference/projections-search.mdx
+++ b/packages/otso.run/src/content/docs/reference/projections-search.mdx
@@ -1,6 +1,8 @@
 ---
 title: Projections & Search
 description: Policies for projections, indexing, and full‑text search.
+sidebar:
+  order: 4
 ---
 
 Projections provide fast read models derived from events.

--- a/packages/otso.run/src/content/docs/reference/storage-adapters.mdx
+++ b/packages/otso.run/src/content/docs/reference/storage-adapters.mdx
@@ -1,6 +1,8 @@
 ---
 title: Storage Adapters
 description: FS‑Markdown, JSONL, SQLite, and Postgres adapters.
+sidebar:
+  order: 3
 ---
 
 Otso ships with multiple storage backends.

--- a/packages/otso.run/src/content/docs/tutorials/backup-restore-snapshots.mdx
+++ b/packages/otso.run/src/content/docs/tutorials/backup-restore-snapshots.mdx
@@ -1,6 +1,8 @@
 ---
 title: Backup & Restore (Snapshots)
 description: Take a snapshot before big operations and restore if needed.
+sidebar:
+  order: 5
 ---
 
 Snapshots let you rewind if a migration goes wrong.

--- a/packages/otso.run/src/content/docs/tutorials/build-simple-site-microformats.mdx
+++ b/packages/otso.run/src/content/docs/tutorials/build-simple-site-microformats.mdx
@@ -1,6 +1,8 @@
 ---
 title: Build a Simple Site with Microformats
 description: Create a basic site that renders posts with mf2 semantics.
+sidebar:
+  order: 2
 ---
 
 This tutorial uses Astro but the concepts apply to any framework.

--- a/packages/otso.run/src/content/docs/tutorials/import-bookmarks-defuddle.mdx
+++ b/packages/otso.run/src/content/docs/tutorials/import-bookmarks-defuddle.mdx
@@ -1,6 +1,8 @@
 ---
 title: Import Bookmarks & Enrich with Defuddle
 description: Bring in bookmarks and clean them up with Defuddle.
+sidebar:
+  order: 4
 ---
 
 ## Import bookmarks

--- a/packages/otso.run/src/content/docs/tutorials/quickstart-install-publish.mdx
+++ b/packages/otso.run/src/content/docs/tutorials/quickstart-install-publish.mdx
@@ -1,6 +1,8 @@
 ---
 title: Quickstart — Install & Publish
 description: Install Otso and publish your first note.
+sidebar:
+  order: 1
 ---
 
 In this tutorial you’ll install Otso and publish your first note.

--- a/packages/otso.run/src/content/docs/tutorials/setup-posse-mastodon.mdx
+++ b/packages/otso.run/src/content/docs/tutorials/setup-posse-mastodon.mdx
@@ -1,6 +1,8 @@
 ---
 title: Set Up POSSE to Mastodon
 description: Connect and syndicate posts to Mastodon.
+sidebar:
+  order: 3
 ---
 
 ## Connect account


### PR DESCRIPTION
## Summary
- add explicit `sidebar.order` frontmatter to docs so pages appear in a logical order

## Testing
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c606a0f98c8325b32bc2df3e17d390