### PR TITLE
docs: categorize supported sources

### DIFF
--- a/packages/otso.run/src/content/docs/overview/sources.mdx
+++ b/packages/otso.run/src/content/docs/overview/sources.mdx
@@ -1,0 +1,70 @@
+---
+title: Supported Sources
+description: Import, sync, and syndication coverage for common services.
+sidebar:
+  order: 7
+---
+
+Otso connects to many services. The table below summarizes which actions are possible for each source.
+
+- `[x]` – supported
+- `[~]` – partial or limited support
+- `[ ]` – not available
+
+| Source | Category | Import | Sync (PESOS) | Syndication (POSSE) |
+| --- | --- | --- | --- | --- |
+| 23andMe | Health | [x] | [ ] | [ ] |
+| Apple Health | Health | [x] | [ ] | [ ] |
+| Apple Notes | Notes | [x] | [ ] | [ ] |
+| Apple Photos | Photos | [x] | [ ] | [ ] |
+| Bluesky (ATProto) | Social | [~] | [x] | [x] |
+| Browser History | Browser | [x] | [ ] | [ ] |
+| Discord | Messaging | [x] | [~] | [ ] |
+| Evernote | Notes | [x] | [ ] | [ ] |
+| Fitbit | Fitness | [x] | [ ] | [ ] |
+| Flickr | Photos | [x] | [~] | [x] |
+| Foursquare / Swarm | Location | [x] | [~] | [ ] |
+| Ghost | Blog | [x] | [~] | [x] |
+| GitHub | Code | [x] | [x] | [x] |
+| GitLab | Code | [x] | [~] | [~] |
+| Gmail | Email | [x] | [ ] | [ ] |
+| Google Calendar | Calendar | [x] | [ ] | [ ] |
+| Google Drive | Files | [x] | [ ] | [ ] |
+| Google Location History | Location | [x] | [ ] | [ ] |
+| Google Photos | Photos | [x] | [ ] | [ ] |
+| Google Takeout | Export | [x] | [ ] | [ ] |
+| Goodreads | Books | [x] | [ ] | [ ] |
+| Hacker News | Social | [x] | [ ] | [ ] |
+| Hypothesis | Annotations | [x] | [ ] | [ ] |
+| iCal / ICS | Calendar | [x] | [x] | [ ] |
+| iNaturalist | Science | [x] | [ ] | [ ] |
+| Instapaper | Reading | [x] | [ ] | [ ] |
+| Instagram | Social | [x] | [ ] | [~] |
+| Kindle | Books | [x] | [ ] | [ ] |
+| Kobo | Books | [x] | [ ] | [ ] |
+| Last.fm | Music | [x] | [ ] | [ ] |
+| Matrix | Messaging | [~] | [x] | [x] |
+| Mastodon / Fediverse | Social | [~] | [x] | [x] |
+| Medium | Blog | [x] | [ ] | [x] |
+| Micro.blog | Blog | [x] | [~] | [x] |
+| Notion | Notes | [x] | [~] | [ ] |
+| Obsidian / Markdown | Notes | [x] | [x] | [x] |
+| Overcast | Podcast | [x] | [ ] | [ ] |
+| Pinboard | Bookmarks | [x] | [x] | [ ] |
+| Pocket | Bookmarks | [x] | [~] | [ ] |
+| Polar | Fitness | [x] | [ ] | [ ] |
+| Raindrop.io | Bookmarks | [x] | [x] | [ ] |
+| Readwise | Reading | [x] | [x] | [ ] |
+| Reddit | Social | [x] | [ ] | [ ] |
+| Signal | Messaging | [x] | [ ] | [ ] |
+| Slack | Messaging | [x] | [~] | [ ] |
+| Spotify | Music | [x] | [ ] | [ ] |
+| Stack Overflow | Q&A | [x] | [~] | [ ] |
+| Strava | Fitness | [x] | [x] | [x] |
+| Telegram | Messaging | [x] | [ ] | [ ] |
+| Threads (Meta) | Social | [ ] | [ ] | [~] |
+| Twitter / X | Social | [x] | [ ] | [~] |
+| Vimeo | Video | [x] | [~] | [x] |
+| WhatsApp | Messaging | [x] | [ ] | [ ] |
+| WordPress | Blog | [x] | [x] | [x] |
+| YouTube | Video | [x] | [~] | [x] |


### PR DESCRIPTION
## Summary
- add category column and alphabetical sorting to supported sources table
- expand list to cover Dogsheep, HPI, and Chronicle sources (e.g. 23andMe, Gmail, Goodreads)

## Testing
- `pnpm --filter otso.run build`


------
https://chatgpt.com/codex/tasks/task_e_68c607e9fbd4832593f1414c828244ad