### PR TITLE
docs: replace source status text with emojis

### DIFF
--- a/packages/otso.run/src/content/docs/overview/sources.mdx
+++ b/packages/otso.run/src/content/docs/overview/sources.mdx
@@ -7,64 +7,64 @@ sidebar:
 
 Otso connects to many services. The table below summarizes which actions are possible for each source.
 
-- `[x]` – supported
-- `[~]` – partial or limited support
-- `[ ]` – not available
+- `✅` – supported
+- `🟡` – partial or limited support
+- `❌` – not available
 
 | Source | Category | Import | Sync (PESOS) | Syndication (POSSE) |
 | --- | --- | --- | --- | --- |
-| 23andMe | Health | [x] | [ ] | [ ] |
-| Apple Health | Health | [x] | [ ] | [ ] |
-| Apple Notes | Notes | [x] | [ ] | [ ] |
-| Apple Photos | Photos | [x] | [ ] | [ ] |
-| Bluesky (ATProto) | Social | [~] | [x] | [x] |
-| Browser History | Browser | [x] | [ ] | [ ] |
-| Discord | Messaging | [x] | [~] | [ ] |
-| Evernote | Notes | [x] | [ ] | [ ] |
-| Fitbit | Fitness | [x] | [ ] | [ ] |
-| Flickr | Photos | [x] | [~] | [x] |
-| Foursquare / Swarm | Location | [x] | [~] | [ ] |
-| Ghost | Blog | [x] | [~] | [x] |
-| GitHub | Code | [x] | [x] | [x] |
-| GitLab | Code | [x] | [~] | [~] |
-| Gmail | Email | [x] | [ ] | [ ] |
-| Google Calendar | Calendar | [x] | [ ] | [ ] |
-| Google Drive | Files | [x] | [ ] | [ ] |
-| Google Location History | Location | [x] | [ ] | [ ] |
-| Google Photos | Photos | [x] | [ ] | [ ] |
-| Google Takeout | Export | [x] | [ ] | [ ] |
-| Goodreads | Books | [x] | [ ] | [ ] |
-| Hacker News | Social | [x] | [ ] | [ ] |
-| Hypothesis | Annotations | [x] | [ ] | [ ] |
-| iCal / ICS | Calendar | [x] | [x] | [ ] |
-| iNaturalist | Science | [x] | [ ] | [ ] |
-| Instapaper | Reading | [x] | [ ] | [ ] |
-| Instagram | Social | [x] | [ ] | [~] |
-| Kindle | Books | [x] | [ ] | [ ] |
-| Kobo | Books | [x] | [ ] | [ ] |
-| Last.fm | Music | [x] | [ ] | [ ] |
-| Matrix | Messaging | [~] | [x] | [x] |
-| Mastodon / Fediverse | Social | [~] | [x] | [x] |
-| Medium | Blog | [x] | [ ] | [x] |
-| Micro.blog | Blog | [x] | [~] | [x] |
-| Notion | Notes | [x] | [~] | [ ] |
-| Obsidian / Markdown | Notes | [x] | [x] | [x] |
-| Overcast | Podcast | [x] | [ ] | [ ] |
-| Pinboard | Bookmarks | [x] | [x] | [ ] |
-| Pocket | Bookmarks | [x] | [~] | [ ] |
-| Polar | Fitness | [x] | [ ] | [ ] |
-| Raindrop.io | Bookmarks | [x] | [x] | [ ] |
-| Readwise | Reading | [x] | [x] | [ ] |
-| Reddit | Social | [x] | [ ] | [ ] |
-| Signal | Messaging | [x] | [ ] | [ ] |
-| Slack | Messaging | [x] | [~] | [ ] |
-| Spotify | Music | [x] | [ ] | [ ] |
-| Stack Overflow | Q&A | [x] | [~] | [ ] |
-| Strava | Fitness | [x] | [x] | [x] |
-| Telegram | Messaging | [x] | [ ] | [ ] |
-| Threads (Meta) | Social | [ ] | [ ] | [~] |
-| Twitter / X | Social | [x] | [ ] | [~] |
-| Vimeo | Video | [x] | [~] | [x] |
-| WhatsApp | Messaging | [x] | [ ] | [ ] |
-| WordPress | Blog | [x] | [x] | [x] |
-| YouTube | Video | [x] | [~] | [x] |
+| 23andMe | Health | ✅ | ❌ | ❌ |
+| Apple Health | Health | ✅ | ❌ | ❌ |
+| Apple Notes | Notes | ✅ | ❌ | ❌ |
+| Apple Photos | Photos | ✅ | ❌ | ❌ |
+| Bluesky (ATProto) | Social | 🟡 | ✅ | ✅ |
+| Browser History | Browser | ✅ | ❌ | ❌ |
+| Discord | Messaging | ✅ | 🟡 | ❌ |
+| Evernote | Notes | ✅ | ❌ | ❌ |
+| Fitbit | Fitness | ✅ | ❌ | ❌ |
+| Flickr | Photos | ✅ | 🟡 | ✅ |
+| Foursquare / Swarm | Location | ✅ | 🟡 | ❌ |
+| Ghost | Blog | ✅ | 🟡 | ✅ |
+| GitHub | Code | ✅ | ✅ | ✅ |
+| GitLab | Code | ✅ | 🟡 | 🟡 |
+| Gmail | Email | ✅ | ❌ | ❌ |
+| Google Calendar | Calendar | ✅ | ❌ | ❌ |
+| Google Drive | Files | ✅ | ❌ | ❌ |
+| Google Location History | Location | ✅ | ❌ | ❌ |
+| Google Photos | Photos | ✅ | ❌ | ❌ |
+| Google Takeout | Export | ✅ | ❌ | ❌ |
+| Goodreads | Books | ✅ | ❌ | ❌ |
+| Hacker News | Social | ✅ | ❌ | ❌ |
+| Hypothesis | Annotations | ✅ | ❌ | ❌ |
+| iCal / ICS | Calendar | ✅ | ✅ | ❌ |
+| iNaturalist | Science | ✅ | ❌ | ❌ |
+| Instapaper | Reading | ✅ | ❌ | ❌ |
+| Instagram | Social | ✅ | ❌ | 🟡 |
+| Kindle | Books | ✅ | ❌ | ❌ |
+| Kobo | Books | ✅ | ❌ | ❌ |
+| Last.fm | Music | ✅ | ❌ | ❌ |
+| Matrix | Messaging | 🟡 | ✅ | ✅ |
+| Mastodon / Fediverse | Social | 🟡 | ✅ | ✅ |
+| Medium | Blog | ✅ | ❌ | ✅ |
+| Micro.blog | Blog | ✅ | 🟡 | ✅ |
+| Notion | Notes | ✅ | 🟡 | ❌ |
+| Obsidian / Markdown | Notes | ✅ | ✅ | ✅ |
+| Overcast | Podcast | ✅ | ❌ | ❌ |
+| Pinboard | Bookmarks | ✅ | ✅ | ❌ |
+| Pocket | Bookmarks | ✅ | 🟡 | ❌ |
+| Polar | Fitness | ✅ | ❌ | ❌ |
+| Raindrop.io | Bookmarks | ✅ | ✅ | ❌ |
+| Readwise | Reading | ✅ | ✅ | ❌ |
+| Reddit | Social | ✅ | ❌ | ❌ |
+| Signal | Messaging | ✅ | ❌ | ❌ |
+| Slack | Messaging | ✅ | 🟡 | ❌ |
+| Spotify | Music | ✅ | ❌ | ❌ |
+| Stack Overflow | Q&A | ✅ | 🟡 | ❌ |
+| Strava | Fitness | ✅ | ✅ | ✅ |
+| Telegram | Messaging | ✅ | ❌ | ❌ |
+| Threads (Meta) | Social | ❌ | ❌ | 🟡 |
+| Twitter / X | Social | ✅ | ❌ | 🟡 |
+| Vimeo | Video | ✅ | 🟡 | ✅ |
+| WhatsApp | Messaging | ✅ | ❌ | ❌ |
+| WordPress | Blog | ✅ | ✅ | ✅ |
+| YouTube | Video | ✅ | 🟡 | ✅ |


### PR DESCRIPTION
## Summary
- use ✅ 🟡 ❌ emojis instead of placeholder text in Supported Sources table

## Testing
- `pnpm --filter otso.run build`

------
https://chatgpt.com/codex/tasks/task_e_68c60c19a774832595f9afa865db16df