### PR TITLE
docs: add pages for future extensions

### DIFF
--- a/packages/otso.run/src/content/docs/overview/alternative-outputs.mdx
+++ b/packages/otso.run/src/content/docs/overview/alternative-outputs.mdx
@@ -1,0 +1,14 @@
+---
+title: Alternative Outputs
+description: Export content beyond a website.
+sidebar:
+  order: 15
+---
+
+Otso is not limited to generating a public site. Planned export targets include:
+
+- Zipped archives of your full event log or site.
+- Markdown or JSONL dumps for long-term storage.
+- PDF or print-ready bundles for portable collections.
+
+These exports let you move or share your data on your own terms.

--- a/packages/otso.run/src/content/docs/overview/desktop-app.mdx
+++ b/packages/otso.run/src/content/docs/overview/desktop-app.mdx
@@ -1,0 +1,13 @@
+---
+title: Desktop App
+description: Tauri-based desktop shell for drag-and-drop imports and local control.
+sidebar:
+  order: 16
+---
+
+A lightweight desktop app built with Tauri brings Otso's tooling to macOS, Windows, and Linux.
+
+- Drag and drop archive ZIPs to import.
+- Local-first storage with access to system keychains.
+- Reuses the Svelte UI and talks to the core through Tauri commands.
+- Small footprint and auto-updating releases.

--- a/packages/otso.run/src/content/docs/overview/headless-micropub.mdx
+++ b/packages/otso.run/src/content/docs/overview/headless-micropub.mdx
@@ -1,0 +1,13 @@
+---
+title: Headless Micropub & Extension API
+description: Exposing Otso's commands and plugin hooks without the UI.
+sidebar:
+  order: 13
+---
+
+Beyond the bundled apps, Otso exposes its Micropub implementation and plugin system as headless services.
+
+- `@otso/protocol-micropub` provides a Micropub client and optional server.
+- Plugins register capabilities such as storage, publishers, or enrichers.
+- Capabilities are discoverable so custom interfaces can adapt dynamically.
+- Build custom extensions without touching the core.

--- a/packages/otso.run/src/content/docs/overview/ios-app.mdx
+++ b/packages/otso.run/src/content/docs/overview/ios-app.mdx
@@ -1,0 +1,13 @@
+---
+title: iOS App
+description: Fast Micropub client for quick capture and offline posting.
+sidebar:
+  order: 10
+---
+
+The Otso iOS app focuses on one-thumb publishing. It stores drafts locally, syncs in the background, and supports the full Micropub post kinds.
+
+- IndieAuth login with multi-account support.
+- Compose notes, articles, photos, replies, reposts, likes, bookmarks, check-ins, and RSVPs.
+- Local-first engine with SQLite drafts and an outbox queue for retryable sync.
+- Built with Swift and modern SwiftUI patterns.

--- a/packages/otso.run/src/content/docs/overview/local-ai-agents.mdx
+++ b/packages/otso.run/src/content/docs/overview/local-ai-agents.mdx
@@ -1,0 +1,13 @@
+---
+title: Local AI Agents
+description: Optional helpers for summaries, tags, and cleaned reading views.
+sidebar:
+  order: 14
+---
+
+AI features in Otso are opt-in. You can run local models or connect to hosted ones to enrich your archive.
+
+- Generate summaries, keywords, or alt-text for imports.
+- Produce cleaned reading views for saved links.
+- Store provenance so you can redo enrichment with better models later.
+- Completely optional—the core works without any AI.

--- a/packages/otso.run/src/content/docs/overview/protocol-plugins.mdx
+++ b/packages/otso.run/src/content/docs/overview/protocol-plugins.mdx
@@ -1,0 +1,18 @@
+---
+title: Protocol Plugins
+description: Standard protocol adapters like Micropub, Webmention, ActivityPub, and more.
+sidebar:
+  order: 9
+---
+
+Otso treats network protocols as pluggable modules. A protocol plugin defines how the core speaks a standard like Micropub or Webmention, and multiple publishers can build on top of it.
+
+Current and planned protocol plugins include:
+
+- Micropub client and optional server.
+- Webmention send/receive.
+- WebSub for push feeds.
+- ActivityPub bridge for the Fediverse.
+- Experimental ideas such as AT Protocol, Nostr, or IPFS.
+
+Protocol plugins power publishers: an ActivityPub plugin can serve both Mastodon importers and posting adapters.

--- a/packages/otso.run/src/content/docs/overview/sdk.mdx
+++ b/packages/otso.run/src/content/docs/overview/sdk.mdx
@@ -1,0 +1,12 @@
+---
+title: Otso SDK
+description: Composable core and plugin API for building on top of Otso.
+sidebar:
+  order: 8
+---
+
+Otso's heart is a small TypeScript SDK that exposes the event log, domain models, and typed commands. Interfaces like the CLI, web app, or iOS app all consume the same package, while plugins register storage adapters, importers, publishers, and enrichers.
+
+- Tiny core with commands such as `createPost`, `import`, and `publish`.
+- Typed event bus so plugins react to changes instead of poking internals.
+- Shared across surfaces: CLI, Svelte app, iOS, or future desktop builds.

--- a/packages/otso.run/src/content/docs/overview/share-sheet.mdx
+++ b/packages/otso.run/src/content/docs/overview/share-sheet.mdx
@@ -1,0 +1,13 @@
+---
+title: Share Sheet
+description: iOS extension for sending text, links, or photos into Otso.
+sidebar:
+  order: 11
+---
+
+A share extension lets any app hand content to Otso. From Safari, Photos, or a reader, choose Otso in the share sheet to create a draft instantly.
+
+- Accepts text, URLs, images, or files.
+- Prompts for post kind before queuing the item.
+- Works with Shortcuts and App Intents for quick capture flows.
+- Respects the same local-first queue as the main app.

--- a/packages/otso.run/src/content/docs/overview/web-app.mdx
+++ b/packages/otso.run/src/content/docs/overview/web-app.mdx
@@ -1,0 +1,13 @@
+---
+title: Svelte Web App
+description: Browser dashboard for composing and hosting your site.
+sidebar:
+  order: 12
+---
+
+Otso ships a SvelteKit web app that doubles as a dashboard and the default site theme.
+
+- Compose posts and browse your archive in a lightweight interface.
+- Manage accounts and syndication targets.
+- Generate a clean personal site using Microformats2.
+- Runs locally or deploys as a static site.


### PR DESCRIPTION
## Summary
- document the Otso SDK and protocol plugin model
- add overview pages for the iOS app, share sheet, Svelte web app, headless Micropub API, optional AI helpers, alternative exports, and desktop app

## Testing
- `pnpm --filter otso.run build`

------
https://chatgpt.com/codex/tasks/task_e_68c613c99d248325a98af65d501bde21