### PR TITLE
docs: add icons to home categories

### DIFF
--- a/packages/otso.run/src/content/docs/index.mdx
+++ b/packages/otso.run/src/content/docs/index.mdx
@@ -20,7 +20,7 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 ## Start here
 
 <CardGrid stagger>
-	<Card title="Overview" icon="info">
+        <Card title="Overview" icon="information">
 		What Otso is and why it matters.
 		
 		– [What is Otso?](/overview/what-is-otso/)
@@ -34,26 +34,26 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
                 – [Quickstart](/tutorials/quickstart-install-publish/)
         </Card>
-	<Card title="How‑to Guides" icon="list">
+        <Card title="How‑to Guides" icon="list-format">
 		Task‑oriented recipes.
 		
 		– [Import from GitHub](/how-to/import-github/)
 		
 		– [Publish to Mastodon](/how-to/publish-mastodon/)
 	</Card>
-	<Card title="Reference" icon="database">
+        <Card title="Reference" icon="document">
 		Exact behavior and specs.
 		
 		– [CLI commands](/reference/cli-commands/)
 		
 		– [Event model](/reference/event-model/)
 	</Card>
-	<Card title="Explanations" icon="thinking">
+        <Card title="Explanations" icon="comment">
 		Concepts and trade‑offs.
 		
 		– [POSSE vs PESOS](/explanations/posse-vs-pesos/)
 	</Card>
-	<Card title="Appendix" icon="book">
+        <Card title="Appendix" icon="open-book">
 		Supporting material.
 		
 		– [Schema mappings](/appendix/data-schema-mappings/)


### PR DESCRIPTION
## Summary
- use supported Starlight icons for Overview, How-to Guides, Reference, Explanations, and Appendix cards

## Testing
- `pnpm build`

------
https://chatgpt.com/codex/tasks/task_e_68c617d641a083259f1b3445bb7dbd59