### PR TITLE
docs: expand homepage navigation

### DIFF
--- a/packages/otso.run/src/content/docs/index.mdx
+++ b/packages/otso.run/src/content/docs/index.mdx
@@ -29,15 +29,21 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 		– [Ecosystem — Alternatives & Inspirations](/explanations/ecosystem-alternatives-inspirations/)
 	</Card>
-        <Card title="Quickstart" icon="rocket">
-                Install Otso then choose your next step.
+        <Card title="Tutorials" icon="rocket">
+                Step‑by‑step introductions.
 
                 – [Quickstart](/tutorials/quickstart-install-publish/)
+
+                – [Build a simple site](/tutorials/build-simple-site-microformats/)
+
+                – [Set up POSSE to Mastodon](/tutorials/setup-posse-mastodon/)
         </Card>
         <Card title="Guides" icon="list-format">
                 Task‑oriented recipes.
 
                 – [Import from GitHub](/guides/import-github/)
+
+                – [Import from Bluesky](/guides/import-bluesky/)
 
                 – [Publish to Mastodon](/guides/publish-mastodon/)
         </Card>
@@ -49,10 +55,16 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
                 – [Event model](/reference/event-model/)
 
                 – [Schema mappings](/reference/data-schema-mappings/)
+
+                – [Plugin architecture](/reference/plugin-architecture/)
         </Card>
         <Card title="Explanations" icon="comment">
                 Concepts and trade‑offs.
-		
-		– [POSSE vs PESOS](/explanations/posse-vs-pesos/)
-	</Card>
+
+                – [POSSE vs PESOS](/explanations/posse-vs-pesos/)
+
+                – [Local‑first choices](/explanations/local-first-choices/)
+
+                – [Event‑driven design](/explanations/event-driven-design/)
+        </Card>
 </CardGrid>


### PR DESCRIPTION
## Summary
- broaden homepage sections with more tutorial, guide, and reference links

## Testing
- `pnpm --filter otso.run build`


------
https://chatgpt.com/codex/tasks/task_e_68c61db92f0c8325ab90619021bbf84c