### PR TITLE
docs: expand quickstart use cases

### DIFF
--- a/packages/otso.run/src/content/docs/index.mdx
+++ b/packages/otso.run/src/content/docs/index.mdx
@@ -32,6 +32,9 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
                 – [Tag your bookmarks from Pinboard and Readwise using a local AI model](/tutorials/quickstart-install-publish/#tag-your-bookmarks-from-pinboard-and-readwise-using-a-local-ai-model)
 
                 – [Generate searchable descriptions from your screenshots folder](/tutorials/quickstart-install-publish/#generate-searchable-descriptions-from-your-screenshots-folder)
+                – [Visualize your music listening across sites](/tutorials/quickstart-install-publish/#visualize-your-music-listening-across-sites)
+                – [Ask questions of your Notion docs using a local AI model](/tutorials/quickstart-install-publish/#ask-questions-of-your-notion-docs-using-a-local-ai-model)
+                – [Migrate bookmarks from Pinboard to Raindrop with a searchable local copy](/tutorials/quickstart-install-publish/#migrate-pinboard-bookmarks-to-raindrop-with-a-searchable-local-copy)
         </Card>
         <Card title="Overview" icon="information">
                 What Otso is and why it matters.

--- a/packages/otso.run/src/content/docs/tutorials/quickstart-install-publish.mdx
+++ b/packages/otso.run/src/content/docs/tutorials/quickstart-install-publish.mdx
@@ -75,11 +75,48 @@ See [Import Bookmarks & Enrich with Defuddle](/tutorials/import-bookmarks-defudd
 
 ### Generate searchable descriptions from your screenshots folder
 
-Pull images from a folder and auto‑caption them for search.
+Pull images from a folder, auto‑caption them, then search by description.
 
 ```bash
 otso import folder ~/Pictures/Screenshots
 otso enrich describe --model local
+```
+
+Search later and see matches highlighted:
+
+```bash
+otso search "concert ticket" --images
+```
+
+> ~/Pictures/Screenshots/live-show.png — "July 4 **concert ticket**"
+
+### Visualize your music listening across sites
+
+Combine listening history from multiple services into one timeline.
+
+```bash
+otso import lastfm --since 30d
+otso import spotify --since 30d
+otso view music-timeline
+```
+
+### Ask questions of your Notion docs using a local AI model
+
+Pull your Notion pages and ask them questions offline.
+
+```bash
+otso import notion --database my-notes
+otso ask "When is the next team meeting?" --model local
+```
+
+### Migrate Pinboard bookmarks to Raindrop with a searchable local copy
+
+Move your links to Raindrop while keeping everything indexed locally.
+
+```bash
+otso import pinboard --all
+otso export raindrop
+otso search "pasta recipe" --bookmarks
 ```
 
 Pick another path anytime—Otso lets you roam.


### PR DESCRIPTION
## Summary
- show searching and highlighted results after generating screenshot descriptions
- add quickstarts for cross-site music visualization, offline Notion Q&A, and Pinboard to Raindrop migrations
- simplify examples and use `otso ask` for Notion questions
- link new use cases from docs index

## Testing
- `pnpm --filter otso.run install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c6380c5d08832580202e3df7c95002