### PR TITLE
docs: document Mastodon PESOS sync

### DIFF
--- a/packages/otso.run/src/content/docs/guides/import-mastodon.mdx
+++ b/packages/otso.run/src/content/docs/guides/import-mastodon.mdx
@@ -19,6 +19,20 @@ Download your account archive, unzip, and run:
 otso import mastodon --archive ~/Downloads/mastodon-export
 ```
 
+## Run as a PESOS job
+
+`otso import mastodon` is idempotent, so you can run it regularly to keep
+your site and local archive up to date. Execute it on demand or deploy it
+to a cron or serverless worker to poll Mastodon on a schedule and sync the
+results back to your local environment.
+
+Use `otso run` to deploy the import on a timer, for example every 15 minutes
+on Vercel:
+
+```bash
+otso run --every 15m --on vercel import mastodon --include likes,replies
+```
+
 ## Mapping
 
 - Toots → `note`

--- a/packages/otso.run/src/content/docs/tutorials/quickstart-install-publish.mdx
+++ b/packages/otso.run/src/content/docs/tutorials/quickstart-install-publish.mdx
@@ -42,11 +42,20 @@ See [Import Twitter/X Archive](/guides/import-twitter-archives/) for details.
 
 ### Automatically sync your Mastodon posts, likes, and replies to your website and local storage
 
-Pull in new activity and mirror it to your site.
+Run this as a PESOS job—like Bridgy or Echofeed—to pull your Mastodon
+activity into your local archive and mirror it to your site. You can run
+it locally on demand or deploy it as a scheduled job on a serverless or
+cron service.
 
 ```bash
 otso import mastodon --include likes,replies --since 7d
 otso publish site
+```
+
+Deploy a recurring import every 15 minutes on Vercel:
+
+```bash
+otso run --every 15m --on vercel import mastodon --include likes,replies
 ```
 
 More options in [Import from Mastodon](/guides/import-mastodon/).


### PR DESCRIPTION
## Summary
- explain that Mastodon imports can run as a PESOS job similar to Bridgy or Echofeed
- note that `otso import mastodon` can run on demand or scheduled to keep local archive in sync
- show `otso run --every 15m --on vercel import mastodon --include likes,replies` to deploy recurring imports

## Testing
- `pnpm install`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68c636f95c0c8325949127aef95a4855