### PR TITLE
docs: clean up sidebar structure

### DIFF
--- a/packages/otso.run/astro.config.mjs
+++ b/packages/otso.run/astro.config.mjs
@@ -46,11 +46,9 @@ export default defineConfig({
 			sidebar: [
                                 { label: 'Overview', autogenerate: { directory: 'overview' } },
                                 { label: 'Tutorials', autogenerate: { directory: 'tutorials' } },
-                                { label: 'How‑to Guides', autogenerate: { directory: 'how-to' } },
                                 { label: 'Guides', autogenerate: { directory: 'guides' } },
                                 { label: 'Reference', autogenerate: { directory: 'reference' } },
                                 { label: 'Explanations', autogenerate: { directory: 'explanations' } },
-                                { label: 'Appendix', autogenerate: { directory: 'appendix' } },
                         ],
                 }),
                 sitemap(),

--- a/packages/otso.run/src/content/docs/reference/apps/_meta.yaml
+++ b/packages/otso.run/src/content/docs/reference/apps/_meta.yaml
@@ -1,0 +1,2 @@
+label: Apps
+

--- a/packages/otso.run/src/content/docs/reference/dev/_meta.yaml
+++ b/packages/otso.run/src/content/docs/reference/dev/_meta.yaml
@@ -1,0 +1,2 @@
+label: Development
+

--- a/packages/otso.run/src/content/docs/reference/extensions/_meta.yaml
+++ b/packages/otso.run/src/content/docs/reference/extensions/_meta.yaml
@@ -1,0 +1,2 @@
+label: Extensions
+


### PR DESCRIPTION
## Summary
- drop empty How-to Guides and Appendix sidebar sections
- label sidebar subfolders as Apps, Extensions, and Development

## Testing
- `pnpm --filter otso.run build` *(fails: Cannot find module 'starlight-llms-txt')*


------
https://chatgpt.com/codex/tasks/task_e_68c63c95ce6083259a72ab7619526d63