### PR TITLE
docs: improve quickstarts formatting

### DIFF
--- a/packages/otso.run/src/content/docs/index.mdx
+++ b/packages/otso.run/src/content/docs/index.mdx
@@ -21,20 +21,16 @@ import { Card, CardGrid } from '@astrojs/starlight/components';
 
 <CardGrid stagger>
         <Card title="Quickstarts" icon="rocket">
-                Simple real-world scenarios.
+          Simple real-world scenarios.
 
-                – [Archive a Twitter/X export and publish to your own site](/tutorials/quickstart-install-publish/#archive-a-twitterx-export-and-publish-to-your-own-site)
-
-                – [Automatically sync your Mastodon posts, likes, and replies](/tutorials/quickstart-install-publish/#automatically-sync-your-mastodon-posts-likes-and-replies-to-your-website-and-local-storage)
-
-                – [Publish a note on your website and cross-post it to Bluesky and Mastodon](/tutorials/quickstart-install-publish/#publish-a-note-on-your-website-and-cross-post-it-to-bluesky-and-mastodon)
-
-                – [Tag your bookmarks from Pinboard and Readwise using a local AI model](/tutorials/quickstart-install-publish/#tag-your-bookmarks-from-pinboard-and-readwise-using-a-local-ai-model)
-
-                – [Generate searchable descriptions from your screenshots folder](/tutorials/quickstart-install-publish/#generate-searchable-descriptions-from-your-screenshots-folder)
-                – [Visualize your music listening across sites](/tutorials/quickstart-install-publish/#visualize-your-music-listening-across-sites)
-                – [Ask questions of your Notion docs using a local AI model](/tutorials/quickstart-install-publish/#ask-questions-of-your-notion-docs-using-a-local-ai-model)
-                – [Migrate bookmarks from Pinboard to Raindrop with a searchable local copy](/tutorials/quickstart-install-publish/#migrate-pinboard-bookmarks-to-raindrop-with-a-searchable-local-copy)
+          - 🐦 [Archive a Twitter/X export and publish to your own site](/tutorials/quickstart-install-publish/#archive-a-twitterx-export-and-publish-to-your-own-site)
+          - 🐘 [Automatically sync your Mastodon posts, likes, and replies](/tutorials/quickstart-install-publish/#automatically-sync-your-mastodon-posts-likes-and-replies-to-your-website-and-local-storage)
+          - 🔄 [Publish a note on your website and cross-post it to Bluesky and Mastodon](/tutorials/quickstart-install-publish/#publish-a-note-on-your-website-and-cross-post-it-to-bluesky-and-mastodon)
+          - 🔖 [Tag your bookmarks from Pinboard and Readwise using a local AI model](/tutorials/quickstart-install-publish/#tag-your-bookmarks-from-pinboard-and-readwise-using-a-local-ai-model)
+          - 📸 [Generate searchable descriptions from your screenshots folder](/tutorials/quickstart-install-publish/#generate-searchable-descriptions-from-your-screenshots-folder)
+          - 🎧 [Visualize your music listening across sites](/tutorials/quickstart-install-publish/#visualize-your-music-listening-across-sites)
+          - ❓ [Ask questions of your Notion docs using a local AI model](/tutorials/quickstart-install-publish/#ask-questions-of-your-notion-docs-using-a-local-ai-model)
+          - 🌧️ [Migrate bookmarks from Pinboard to Raindrop with a searchable local copy](/tutorials/quickstart-install-publish/#migrate-pinboard-bookmarks-to-raindrop-with-a-searchable-local-copy)
         </Card>
         <Card title="Overview" icon="information">
                 What Otso is and why it matters.


### PR DESCRIPTION
## Summary
- fix formatting of Quickstarts list on homepage
- add topic-specific emojis to each Quickstart entry

## Testing
- `pnpm --filter otso.run build`

------
https://chatgpt.com/codex/tasks/task_e_68c63e8e33448325a63f9739a65b1346