### PR TITLE
docs: link to Chronicle and list Chronicle plugins

### DIFF
--- a/packages/otso.run/src/content/docs/explanations/ecosystem-alternatives-inspirations.mdx
+++ b/packages/otso.run/src/content/docs/explanations/ecosystem-alternatives-inspirations.mdx
@@ -10,7 +10,7 @@ Otso lives happily in an ecosystem of IndieWeb and local‑first tools. This pag
 ## Prominent adjacent projects
 
 - [DogSheep](https://github.com/dogsheep) — a suite of small, sharp CLIs that export your data into per‑source SQLite databases, usually explored with [Datasette](https://datasette.io/). DogSheep’s philosophy—simple CLIs, SQLite everywhere—influences Otso’s import layer and “rebuildable projections.”
-- Chronicle — a CLI‑first personal data framework built around declarative pipelines, append‑only events, and clear staging→canonical flows. Chronicle inspired Otso’s idempotent imports and event/log mindset. (Link welcome—open an issue with your preferred project reference.)
+- [Chronicle](https://github.com/chronicle-app/chronicle-etl) — a CLI‑first personal data framework built around declarative pipelines, append‑only events, and clear staging→canonical flows. Chronicle inspired Otso’s idempotent imports and event/log mindset.
 - [HPI (Human Programming Interface)](https://github.com/karlicoss/HPI) — a Python library that treats your whole “personal data lake” as one interface (messaging, quantified‑self, PKM, logs, etc.). HPI broadened our view of sources beyond social/bookmarks.
 - [Data Transfer Initiative](https://datatransferinitiative.org/) — a nonprofit championing data portability; a kindred spirit for Otso’s “own your data” ethos.
 - [parallel-flickr](https://github.com/straup/parallel-flickr) — Aaron Straup Cope’s tool for backing up your Flickr photos; an early “own your data” inspiration.

--- a/packages/otso.run/src/content/docs/reference/extensions/sources.mdx
+++ b/packages/otso.run/src/content/docs/reference/extensions/sources.mdx
@@ -17,9 +17,11 @@ Otso connects to many services. The table below summarizes which actions are pos
 | Apple Health | Health | ✅ | ❌ | ❌ |
 | Apple Notes | Notes | ✅ | ❌ | ❌ |
 | Apple Photos | Photos | ✅ | ❌ | ❌ |
+| Apple Podcasts | Podcast | ✅ | ❌ | ❌ |
 | Bluesky (ATProto) | Social | 🟡 | ✅ | ✅ |
 | Browser History | Browser | ✅ | ❌ | ❌ |
 | Discord | Messaging | ✅ | 🟡 | ❌ |
+| Email (IMAP/mbox) | Email | ✅ | ❌ | ❌ |
 | Evernote | Notes | ✅ | ❌ | ❌ |
 | Fitbit | Fitness | ✅ | ❌ | ❌ |
 | Flickr | Photos | ✅ | 🟡 | ✅ |
@@ -37,6 +39,7 @@ Otso connects to many services. The table below summarizes which actions are pos
 | Hacker News | Social | ✅ | ❌ | ❌ |
 | Hypothesis | Annotations | ✅ | ❌ | ❌ |
 | iCal / ICS | Calendar | ✅ | ✅ | ❌ |
+| iMessage | Messaging | ✅ | ❌ | ❌ |
 | iNaturalist | Science | ✅ | ❌ | ❌ |
 | Instapaper | Reading | ✅ | ❌ | ❌ |
 | Instagram | Social | ✅ | ❌ | 🟡 |
@@ -56,6 +59,8 @@ Otso connects to many services. The table below summarizes which actions are pos
 | Raindrop.io | Bookmarks | ✅ | ✅ | ❌ |
 | Readwise | Reading | ✅ | ✅ | ❌ |
 | Reddit | Social | ✅ | ❌ | ❌ |
+| Safari | Browser | ✅ | ❌ | ❌ |
+| Shell | System | ✅ | ❌ | ❌ |
 | Signal | Messaging | ✅ | ❌ | ❌ |
 | Slack | Messaging | ✅ | 🟡 | ❌ |
 | Spotify | Music | ✅ | ❌ | ❌ |
@@ -68,3 +73,4 @@ Otso connects to many services. The table below summarizes which actions are pos
 | WhatsApp | Messaging | ✅ | ❌ | ❌ |
 | WordPress | Blog | ✅ | ✅ | ✅ |
 | YouTube | Video | ✅ | 🟡 | ✅ |
+| Zulip | Messaging | ✅ | ❌ | ❌ |


### PR DESCRIPTION
## Summary
- link to Chronicle ETL project in ecosystem alternatives doc
- add Apple Podcasts, Email (IMAP/mbox), iMessage, Safari, Shell, and Zulip to sources table

## Testing
- `pnpm --filter otso.run build`

------
https://chatgpt.com/codex/tasks/task_e_68c64312a36c83259419030e43bd5f84