### PR TITLE
Remove underlines from homepage cards

### DIFF
--- a/packages/otso.run/astro.config.mjs
+++ b/packages/otso.run/astro.config.mjs
@@ -44,13 +44,14 @@ export default defineConfig({
                                         ]
                                         : []),
                         ],
-			sidebar: [
+                        sidebar: [
                                 { label: 'Overview', autogenerate: { directory: 'overview' } },
                                 { label: 'Tutorials', autogenerate: { directory: 'tutorials' } },
                                 { label: 'Guides', autogenerate: { directory: 'guides' } },
                                 { label: 'Reference', autogenerate: { directory: 'reference' } },
                                 { label: 'Explanations', autogenerate: { directory: 'explanations' } },
                         ],
+                        customCss: ['/src/styles/custom.css'],
                 }),
                 sitemap(),
 	],

--- a/packages/otso.run/src/styles/custom.css
+++ b/packages/otso.run/src/styles/custom.css
@@ -1,0 +1,16 @@
+@layer starlight.components {
+        .card-grid .card .body a {
+                text-decoration: none;
+                border-radius: 0.25rem;
+        }
+
+        .card-grid .card .body a:hover,
+        .card-grid .card .body a:focus-visible {
+                text-decoration: none;
+        }
+
+        .card-grid .card .body a:focus-visible {
+                outline: 2px solid var(--sl-color-white);
+                outline-offset: 0.125rem;
+        }
+}


### PR DESCRIPTION
## Summary
- register a custom stylesheet in Starlight’s config
- remove the default underline styling from homepage card links while adding a visible focus outline

## Testing
- pnpm --filter otso.run build

------
https://chatgpt.com/codex/tasks/task_e_68c8be71281c8325a4d04a1af60d8f4c