### PR TITLE
Add Omnivore to inspirations page

### DIFF
--- a/packages/otso.run/src/content/docs/explanations/ecosystem-alternatives-inspirations.mdx
+++ b/packages/otso.run/src/content/docs/explanations/ecosystem-alternatives-inspirations.mdx
@@ -14,6 +14,7 @@ Otso lives happily in an ecosystem of IndieWeb and local‑first tools. This pag
 - [HPI (Human Programming Interface)](https://github.com/karlicoss/HPI) — a Python library that treats your whole “personal data lake” as one interface (messaging, quantified‑self, PKM, logs, etc.). HPI broadened our view of sources beyond social/bookmarks.
 - [Data Transfer Initiative](https://datatransferinitiative.org/) — a nonprofit championing data portability; a kindred spirit for Otso’s “own your data” ethos.
 - [parallel-flickr](https://github.com/straup/parallel-flickr) — Aaron Straup Cope’s tool for backing up your Flickr photos; an early “own your data” inspiration.
+- [Omnivore](https://github.com/omnivore-app/omnivore) — an open-source, self-hosted, cross-platform read later platform.
 
 ## How Otso differs (at a glance)
 


### PR DESCRIPTION
## Summary
- add Omnivore to the inspirations list as an open-source, self-hosted read-later platform

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da7eabca6c8325820a41cc0a3b6a81